### PR TITLE
streamline startup issues and bootstrapping of AWS credentials

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -7,13 +7,6 @@
 # the bake generator (ci/gen-bake.sh).
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
-# The unprivileged dev account. Defaults to the base image's `vscode` at uid/gid
-# 1000; override (e.g. to match a host user) with `--build-arg`, e.g.
-# `--build-arg USERNAME=alice --build-arg USER_UID=1001 --build-arg USER_GID=1001`.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=1000
-
 USER root
 
 # Remove sudo so the image has no setuid privilege-escalation path.
@@ -25,19 +18,6 @@ RUN export SUDO_FORCE_REMOVE=yes \
   && apt-get -y autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-# Drop the base image's pre-made users (uid >= 1000) and any residual sudoers grant
-# files — the base grants its `vscode` user passwordless sudo via /etc/sudoers.d/vscode,
-# and userdel removes the account but not that file. Then (re)create USERNAME as a
-# plain, unprivileged account at the requested uid/gid.
-RUN getent passwd \
-    | awk -F: '($3 >= 1000) && ($1 != "nobody") {print $1}' \
-    | xargs -r -n 1 userdel -r \
-  && rm -rf /etc/sudoers.d/* \
-  && if [ "${USERNAME}" != "root" ]; then \
-       groupadd --gid "${USER_GID}" "${USERNAME}" || true \
-       && useradd -s /bin/bash -m -u "${USER_UID}" -g "${USER_GID}" "${USERNAME}"; \
-     fi
 
 # Install the VS Code git-auth/IPC scrub (rootfs/etc/profile.d/...) and source it
 # from /etc/bash.bashrc so interactive NON-login shells get it too (the profile.d
@@ -65,7 +45,7 @@ RUN git config --system --unset-all 'credential.https://github.com.helper' 2>/de
 ENV AWS_SHARED_CREDENTIALS_FILE=/creds/aws/credentials
 
 # Default to the unprivileged account (consumers can still `USER root` to install).
-USER ${USERNAME}
+USER vscode
 
 # Keep-alive for `docker run`/compose use as a dev container. CMD is inherited by
 # downstream images (e.g. `default`), so it's set once here. In a real devcontainer

--- a/images/base/README.md
+++ b/images/base/README.md
@@ -13,12 +13,6 @@ The `sudo` package is purged (`SUDO_FORCE_REMOVE`) and the base image's
 privilege-escalation path**. The base image's pre-made users (uid ≥ 1000) are also
 removed, eliminating the passwordless-sudo `vscode` grant the upstream ships.
 
-### Unprivileged user
-
-A single unprivileged account is (re)created and the image **defaults to it**
-(`USER ${USERNAME}`) — consumers can still switch to `USER root` to install
-software, then back. Name and ids are build args (see [Build args](#build-args)).
-
 ### Keep-alive command
 
 Sets `CMD ["sleep", "infinity"]` so the image stays running when used as a dev
@@ -54,21 +48,6 @@ in-terminal fallback.
 > Note: `SSH_AUTH_SOCK` is scrubbed by default here. If you rely on a forwarded
 > SSH agent (e.g. a hardware/FIDO key) in terminals, opt out of just that one — see
 > below.
-
-## Build args
-
-| Arg | Default | Purpose |
-|-----|---------|---------|
-| `USERNAME` | `vscode` | Name of the unprivileged dev account |
-| `USER_UID` | `1000` | Its uid |
-| `USER_GID` | `1000` | Its gid |
-
-```sh
-docker buildx bake base \
-  --set base.args.USERNAME=alice \
-  --set base.args.USER_UID=1001 \
-  --set base.args.USER_GID=1001
-```
 
 ## Customizing
 
@@ -108,11 +87,6 @@ services:
 ```jsonc
 "containerEnv": { "SCRUB_SSH_AUTH_SOCK_ENABLED": "false" }
 ```
-
-### Renaming the dev user / changing uid·gid
-
-Use the [build args](#build-args) above (these *are* build-time — they change the
-image, so they require a rebuild).
 
 ## Secrets & credentials
 

--- a/images/credential-shelf-aws/Dockerfile
+++ b/images/credential-shelf-aws/Dockerfile
@@ -7,17 +7,27 @@
 FROM credential-shelf-base
 
 USER root
-# AWS CLI v2 — apt ships v1, which lacks the SSO credential-export flow.
+# AWS CLI v2 — apt ships v1, which lacks the SSO credential-export flow. yq parses the
+# baked accounts.yaml when rendering ~/.aws/config (mikefarah/yq is a single static binary).
 RUN apt-get update && apt-get install -y --no-install-recommends unzip \
   && arch="$(dpkg --print-architecture)" \
   && case "$arch" in amd64) a=x86_64 ;; arm64) a=aarch64 ;; *) echo "unsupported arch: $arch" >&2; exit 1 ;; esac \
   && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${a}.zip" -o /tmp/awscli.zip \
   && unzip -q /tmp/awscli.zip -d /tmp && /tmp/aws/install \
+  && curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${arch}" -o /usr/local/bin/yq \
+  && chmod 0755 /usr/local/bin/yq \
   && rm -rf /tmp/aws /tmp/awscli.zip /var/lib/apt/lists/*
 
 COPY bin/ /usr/local/bin/
-RUN chmod 0755 /usr/local/bin/vend-aws-creds
+RUN chmod 0755 /usr/local/bin/aws-sidecar-start /usr/local/bin/generate-aws-config \
+      /usr/local/bin/vend-aws-creds
+
+# Baked default: no profiles (idle). Override in a derived image (NOT a /workspace
+# bind-mount) so a scope change is a reviewed rebuild:
+#   FROM ghcr.io/<owner>/devcontainers/credential-shelf-aws:latest
+#   COPY accounts.yaml /etc/credential-shelf/accounts.yaml
+COPY accounts.yaml /etc/credential-shelf/accounts.yaml
 
 USER vscode
 WORKDIR /home/vscode
-CMD ["vend-aws-creds"]
+CMD ["aws-sidecar-start"]

--- a/images/credential-shelf-aws/README.md
+++ b/images/credential-shelf-aws/README.md
@@ -2,23 +2,94 @@
 
 AWS provider for the shelf credential sidecar (`FROM`
 [credential-shelf-base](../credential-shelf-base)). Exports STS credentials for the
-configured profiles from an SSO session and writes the **native AWS shared-credentials
-file** at `/creds/aws/credentials` — the [SECRETS.md](../../docs/SECRETS.md) AWS
-exception. Consumers read it via `AWS_SHARED_CREDENTIALS_FILE=/creds/aws/credentials`.
+profiles in its baked **`accounts.yaml`** from an SSO session and writes the **native AWS
+shared-credentials file** at `/creds/aws/credentials` — the [SECRETS.md](../../docs/SECRETS.md)
+AWS exception. Consumers read it via `AWS_SHARED_CREDENTIALS_FILE=/creds/aws/credentials`.
 
 Published as `ghcr.io/<owner>/devcontainers/credential-shelf-aws`.
 
-## Configuration
+Config is split into two parts, by lifetime: the **upstream SSO session** (start URL +
+region) is plain deployment env, while the **grant table** (which account/role each shelf
+profile maps to) is baked into the image so a scope change is a reviewed rebuild. On
+start, `generate-aws-config` renders the two into `~/.aws/config`; you then log in once.
+
+## (a) How to configure
+
+### Upstream SSO session — env
 
 | Var | Purpose |
 |-----|---------|
-| `VEND_AWS_PROFILES` | space-separated profiles in `~/.aws/config` to vend; the **first** also becomes `[default]` |
+| `VEND_AWS_SSO_START_URL` | your IAM Identity Center start URL (**required**) |
+| `VEND_AWS_SSO_REGION` | SSO region (default `us-east-1`) |
+| `VEND_AWS_SSO_SESSION` | `[sso-session]` name in the generated config (default `sso`) |
 | `VEND_REFRESH_BEFORE` | re-vend when fewer than this many seconds remain (default `900`) |
 
-The full SSO session stays in this container; only the listed roles' ≤1h credentials
-reach the shelf. With no/expired session the loop logs and waits — run `aws sso login`
-here (and see the shared-home note in
-[credential-shelf-base](../credential-shelf-base#deployment-pattern-shelf-sidecars)).
+### Grant table — baked `accounts.yaml`
+
+One entry per role to vend; the **first** also becomes `[default]` on the shelf. Consumers
+select the others with `AWS_PROFILE=<name>`.
+
+```yaml
+profiles:
+  - account_id: "084828590319"
+    role: developer-ai-agent   # the SSO permission-set / role name
+    # name: developer          # optional; defaults to <account_id>-<role>
+    # region: us-west-2        # optional; defaults to VEND_AWS_SSO_REGION
+  - account_id: "084828590319"
+    role: view-only            # → profile name 084828590319-view-only
+  - account_id: "084828590319" # config-only: NOT vended to the shelf (see below)
+    role: github-app-signer
+    name: kms-signer
+    vend: false
+```
+
+Only `account_id` and `role` are required. `name` defaults to `<account_id>-<role>`;
+`region` defaults to `VEND_AWS_SSO_REGION`; `vend` defaults to `true`.
+
+Set `vend: false` on an entry to write it to `~/.aws/config` **but keep it off the
+shelf** — use this for a role another sidecar consumes over the shared `admin-home`
+(e.g. the `kms:Sign` profile `credential-shelf-github` reads via `VEND_GH_AWS_PROFILE`),
+so that capability never reaches consumers.
+
+> **Temporary.** `vend: false` is a shelf-era stopgap: the shelf is all-or-nothing, so a
+> role another sidecar needs has no home except "on the shelf for everyone" or "off it, via
+> the shared home." Once per-container vending lands (the **broker** —
+> [docs/CREDENTIAL-BROKER.md](../../docs/CREDENTIAL-BROKER.md)), that role is granted to the
+> one sidecar that needs it and nowhere else, and this flag goes away.
+
+The baked default is `profiles: []` (the sidecar idles). Provide your own by **deriving an
+image** — not a `/workspace` bind-mount — so a scope change is a reviewed rebuild:
+
+```dockerfile
+FROM ghcr.io/<owner>/devcontainers/credential-shelf-aws:latest
+COPY accounts.yaml /etc/credential-shelf/accounts.yaml
+```
+
+`generate-aws-config` turns this into one `[sso-session]` block plus one `[profile]` per
+entry. The full SSO session stays in this container; only the listed roles' ≤1h
+credentials reach the shelf.
+
+## (b) How to authenticate (once the container is running)
+
+`generate-aws-config` runs at start and writes `~/.aws/config`, but the sidecar can't vend
+until it holds an SSO session. Log in **once per SSO session** (org default ~8h), from a
+**host** terminal — the session lives only in the sidecar, never in a consumer:
+
+```sh
+docker exec -it <project>-credential-shelf-aws-1 aws sso login --sso-session sso
+```
+
+(`sso` is the default session name; use your `VEND_AWS_SSO_SESSION` if you changed it.)
+Within ~60s it vends. Check health from anywhere that mounts the shelf:
+
+```sh
+cat /creds/status/aws        # → ok expires=…   (or: stalled … fix="run 'aws sso login' …")
+```
+
+When the session lapses, consumers' `aws` calls fail with `ExpiredToken` and the loop
+stamps `stalled`; repeat the `aws sso login` above. To prove a fresh config end-to-end
+without waiting for the loop: `docker exec … vend-aws-creds --once` (vends once, exits
+nonzero on failure).
 
 ## Vends
 

--- a/images/credential-shelf-aws/accounts.yaml
+++ b/images/credential-shelf-aws/accounts.yaml
@@ -1,0 +1,18 @@
+# accounts.yaml — the roles this sidecar vends to the shelf (its grant table).
+#
+# Baked into the image, NOT a /workspace bind-mount, so changing vend scope is a reviewed
+# rebuild. One entry per role; the FIRST also becomes the shelf's [default]. The baked
+# default below is empty (the sidecar idles) — override by deriving an image:
+#
+#   FROM ghcr.io/<owner>/devcontainers/credential-shelf-aws:latest
+#   COPY accounts.yaml /etc/credential-shelf/accounts.yaml
+#
+# Only account_id and role are required. name defaults to <account_id>-<role>; region
+# defaults to VEND_AWS_SSO_REGION; vend defaults to true. Example:
+#   profiles:
+#     - account_id: "084828590319"
+#       role: developer-ai-agent   # the SSO permission-set / role name
+#       # name: developer          # optional; AWS_PROFILE=<name> selects it on the shelf
+#       # region: us-west-2        # optional; defaults to VEND_AWS_SSO_REGION
+#       # vend: false              # optional; write to ~/.aws/config but keep OFF the shelf
+profiles: []

--- a/images/credential-shelf-aws/bin/aws-sidecar-start
+++ b/images/credential-shelf-aws/bin/aws-sidecar-start
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# aws-sidecar-start — container entrypoint: render ~/.aws/config once, then vend forever.
+#
+# generate-aws-config is best-effort: if the sidecar is misconfigured (no SSO URL, bad
+# accounts.yaml) it exits nonzero and the vend loop reports the problem via the
+# /creds/status/aws health stamp rather than crash-looping the container.
+set -euo pipefail
+generate-aws-config || true
+exec vend-aws-creds

--- a/images/credential-shelf-aws/bin/generate-aws-config
+++ b/images/credential-shelf-aws/bin/generate-aws-config
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# generate-aws-config — render ~/.aws/config from the baked accounts.yaml + SSO env.
+#
+# The shelf's grant table (which account/role each shelf profile maps to) lives in the
+# baked accounts.yaml; the upstream SSO session (start URL, region) comes from env. This
+# turns the two into a native ~/.aws/config: one [sso-session] block plus one [profile]
+# per entry. It also writes the ordered profile-name list to ~/.aws/.vend-profiles, which
+# vend-aws-creds reads. Run once at container start (see aws-sidecar-start); it needs no
+# SSO session of its own — `aws sso login` happens afterward.
+set -euo pipefail
+. /usr/local/lib/sidecar-lib.sh
+log() { sc_log generate-aws-config "$@"; }
+
+ACCOUNTS="${VEND_AWS_ACCOUNTS_FILE:-/etc/credential-shelf/accounts.yaml}"
+CONFIG="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+PROFILES_FILE="${VEND_AWS_PROFILES_FILE:-$HOME/.aws/.vend-profiles}"
+START_URL="${VEND_AWS_SSO_START_URL:-}"
+SSO_REGION="${VEND_AWS_SSO_REGION:-us-east-1}"
+SESSION="${VEND_AWS_SSO_SESSION:-sso}"
+
+[ -f "$ACCOUNTS" ] || { log "no accounts file at $ACCOUNTS; nothing to generate"; exit 0; }
+count=$(yq '.profiles | length' "$ACCOUNTS" 2>/dev/null || echo 0)
+[ "$count" -gt 0 ] || { log "$ACCOUNTS has no profiles; sidecar will idle"; exit 0; }
+
+[ -n "$START_URL" ] || { log "VEND_AWS_SSO_START_URL is unset but $ACCOUNTS lists $count profile(s); set it in the sidecar env"; exit 1; }
+
+umask 077
+mkdir -p "$(dirname "$CONFIG")"
+tmp=$(mktemp "$(dirname "$CONFIG")/.config.XXXXXX")
+
+{
+  printf '[sso-session %s]\n' "$SESSION"
+  printf 'sso_start_url = %s\n' "$START_URL"
+  printf 'sso_region = %s\n' "$SSO_REGION"
+  printf 'sso_registration_scopes = sso:account:access\n\n'
+} >>"$tmp"
+
+names=()
+for i in $(seq 0 $((count - 1))); do
+  acct=$(yq -r ".profiles[$i].account_id" "$ACCOUNTS")
+  role=$(yq -r ".profiles[$i].role" "$ACCOUNTS")
+  region=$(yq -r ".profiles[$i].region // \"$SSO_REGION\"" "$ACCOUNTS")
+  # NB: not `.vend // true` — yq's // treats a literal `false` as "absent" and returns the
+  # default, so an explicit `vend: false` would wrongly read as true. Read raw; null = true.
+  vend=$(yq -r ".profiles[$i].vend" "$ACCOUNTS")
+  for f in account_id:"$acct" role:"$role"; do
+    if [ -z "${f#*:}" ] || [ "${f#*:}" = null ]; then
+      rm -f "$tmp"; log "profiles[$i] is missing '${f%%:*}' in $ACCOUNTS"; exit 1
+    fi
+  done
+  # name is optional; default to <account_id>-<role>.
+  name=$(yq -r ".profiles[$i].name" "$ACCOUNTS")
+  { [ -n "$name" ] && [ "$name" != null ]; } || name="${acct}-${role}"
+  {
+    printf '[profile %s]\n' "$name"
+    printf 'sso_session = %s\n' "$SESSION"
+    printf 'sso_account_id = %s\n' "$acct"
+    printf 'sso_role_name = %s\n' "$role"
+    printf 'region = %s\n\n' "$region"
+  } >>"$tmp"
+  # vend: false → written to ~/.aws/config (e.g. a kms:Sign role the github sidecar uses
+  # over the shared home) but kept OFF the shelf, so consumers never see those creds.
+  # TEMPORARY: this is a shelf-era stopgap. The shelf is all-or-nothing — a role is either
+  # on it (every consumer) or off it (nobody). `vend: false` is the "off it, reachable only
+  # via the shared home" escape hatch. Once per-container vending lands (the broker, see
+  # docs/CREDENTIAL-BROKER.md), such a role is granted to the ONE sidecar that needs it and
+  # nowhere else, and this flag goes away.
+  [ "$vend" = false ] || names+=("$name")
+done
+
+mv "$tmp" "$CONFIG"
+printf '%s\n' "${names[*]}" >"$PROFILES_FILE"
+log "wrote $CONFIG ($count profile(s)); vending to shelf: ${names[*]:-none} (first → [default])"

--- a/images/credential-shelf-aws/bin/vend-aws-creds
+++ b/images/credential-shelf-aws/bin/vend-aws-creds
@@ -2,11 +2,15 @@
 #
 # vend-aws-creds — AWS provider for the shelf credential sidecar.
 #
-# Exports STS credentials for the profiles in $VEND_AWS_PROFILES (from the SSO session in
-# this container's ~/.aws) and atomically writes the native AWS shared-credentials file
-# at /creds/aws/credentials — the docs/SECRETS.md AWS exception. The first profile also
-# becomes [default]; consumers select others with AWS_PROFILE=<name>. The full SSO
-# session stays in this container; only the listed roles' ≤1h creds reach the shelf.
+# Exports STS credentials for the shelf profiles (rendered into this container's
+# ~/.aws/config from the baked accounts.yaml by generate-aws-config) and atomically writes
+# the native AWS shared-credentials file at /creds/aws/credentials — the docs/SECRETS.md
+# AWS exception. The first profile also becomes [default]; consumers select others with
+# AWS_PROFILE=<name>. The full SSO session stays in this container; only the listed roles'
+# ≤1h creds reach the shelf.
+#
+# The profile list comes from ~/.aws/.vend-profiles (written by generate-aws-config), or
+# from $VEND_AWS_PROFILES if set (overrides the file — handy for `--once` testing).
 #
 # With no/expired SSO session it logs and waits — run `aws sso login` in this container.
 # `vend-aws-creds --once` vends a single time and exits nonzero on failure.
@@ -14,6 +18,7 @@ set -euo pipefail
 . /usr/local/lib/sidecar-lib.sh
 
 PROFILES="${VEND_AWS_PROFILES:-}"
+[ -n "$PROFILES" ] || PROFILES="$(cat "${VEND_AWS_PROFILES_FILE:-$HOME/.aws/.vend-profiles}" 2>/dev/null || true)"
 SHELF="$SC_SHELF_DIR/aws"
 REFRESH_BEFORE="${VEND_REFRESH_BEFORE:-900}" # re-vend when < 15 min remain
 CHECK_INTERVAL="${VEND_CHECK_INTERVAL:-60}"

--- a/sample-configs/03-vending/README.md
+++ b/sample-configs/03-vending/README.md
@@ -8,6 +8,7 @@ project's `.devcontainer/` (it includes `github-creds/`).
 ```
 workspace                  the dev container (default image, or build your own FROM it)
 credential-shelf-aws       vends AWS role creds → /creds/aws/credentials
+  └ aws-creds/             a tiny derived image that bakes YOUR accounts.yaml
 credential-shelf-github    vends per-org GitHub App tokens → /creds/github/<org>
   └ github-creds/          a tiny derived image that bakes YOUR installations.json
 ```
@@ -17,8 +18,13 @@ shims**. `git push/pull` over HTTPS and `aws`/`gh` work once the sidecars are ve
 
 ## 1. Fill in before first run
 
-- **`docker-compose.yml`**: `GH_DEFAULT_ORG`, `VEND_AWS_PROFILES`, `VEND_GH_APP_ID`,
-  `VEND_GH_KMS_KEY_ID`, `VEND_GH_AWS_PROFILE` (the `<placeholders>`).
+- **`docker-compose.yml`**: `GH_DEFAULT_ORG`, `VEND_AWS_SSO_START_URL`,
+  `VEND_AWS_SSO_REGION`, `VEND_GH_APP_ID`, `VEND_GH_KMS_KEY_ID`, `VEND_GH_AWS_PROFILE`
+  (the `<placeholders>`).
+- **`aws-creds/accounts.yaml`**: the account/role(s) to vend; the first becomes the shelf
+  `[default]`. Each profile name defaults to `<account_id>-<role>` — set `name:` to override
+  with a friendlier `AWS_PROFILE=<name>`. Point `VEND_GH_AWS_PROFILE` at the `vend: false`
+  kms-signer entry here (give it an explicit `name`, since you reference it).
 - **`github-creds/installations.json`**: your org(s) + installation id(s) (+ optional
   `repos`/`perms`). Empty `[]` → GitHub vending idles.
 
@@ -36,11 +42,10 @@ Both sidecars share the `admin-home` volume, so **one** login serves both. From 
 terminal (the sidecars hold your SSO session; the workspace never does):
 
 ```sh
-# bring up the sidecars
+# bring up the sidecars (the AWS one renders ~/.aws/config from accounts.yaml on start)
 docker compose -p <project> up -d credential-shelf-aws credential-shelf-github
-# set up ~/.aws/config (your SSO start URL + the agent/kms profiles) in the shared home,
-# then log in — its cache lands in admin-home and both sidecars use it:
-docker exec -it <project>-credential-shelf-aws-1 aws sso login --profile <your-agent-profile>
+# log in once — the cache lands in the shared admin-home, so both sidecars use it:
+docker exec -it <project>-credential-shelf-aws-1 aws sso login --sso-session sso
 ```
 
 Within ~60s both vend. Check health from anywhere with the volume:

--- a/sample-configs/03-vending/aws-creds/Dockerfile
+++ b/sample-configs/03-vending/aws-creds/Dockerfile
@@ -1,0 +1,6 @@
+# Derived AWS credential sidecar that bakes THIS project's accounts.yaml — a reviewed
+# rebuild, NOT a /workspace bind-mount, so changing vend scope is human-gated. Fill
+# accounts.yaml with the account/role(s) to vend; SSO start URL + region are env (see
+# docker-compose.yml).
+FROM ghcr.io/skleinjung/devcontainers/credential-shelf-aws:latest
+COPY accounts.yaml /etc/credential-shelf/accounts.yaml

--- a/sample-configs/03-vending/aws-creds/accounts.yaml
+++ b/sample-configs/03-vending/aws-creds/accounts.yaml
@@ -1,0 +1,18 @@
+# Roles this sidecar vends to the shelf. One entry per role; the FIRST also becomes the
+# shelf's [default]. Consumers select the others with AWS_PROFILE=<name>. Empty → idle.
+# See images/credential-shelf-aws for the full reference.
+profiles:
+  - account_id: "<account-id>"     # the FIRST entry becomes the shelf [default]
+    role: <permission-set-name>    # e.g. developer-ai-agent
+    # name defaults to <account-id>-<role>, e.g. 084828590319-developer-ai-agent;
+    # uncomment to pick a friendlier AWS_PROFILE=<name>:
+    # name: <your-agent-profile>
+  # The github sidecar reads its kms:Sign role from the shared ~/.aws/config. Add it here
+  # with vend: false so it lands in the config but NOT on the shelf, then point
+  # VEND_GH_AWS_PROFILE at this name. Drop this entry if you don't run the github sidecar.
+  # (Temporary: the broker will vend this straight to the github sidecar instead — see
+  # images/credential-shelf-aws and docs/CREDENTIAL-BROKER.md.)
+  - name: <kms-signer-profile>
+    account_id: "<account-id>"
+    role: <kms-signer-role>
+    vend: false

--- a/sample-configs/03-vending/docker-compose.yml
+++ b/sample-configs/03-vending/docker-compose.yml
@@ -33,12 +33,13 @@ services:
   # Both share the `admin-home` volume, so a single `aws sso login` serves both. That
   # home (the SSO session) is mounted into NO consumer — only the sidecars.
   credential-shelf-aws:
-    image: ghcr.io/skleinjung/devcontainers/credential-shelf-aws:latest
+    build: ./aws-creds              # bakes aws-creds/accounts.yaml (reviewed rebuild)
     init: true
     restart: unless-stopped
     environment:
-      # space-separated ~/.aws/config profile(s) to vend; the first also becomes [default]
-      VEND_AWS_PROFILES: <your-agent-profile>
+      # upstream SSO session; the account/role(s) to vend live in aws-creds/accounts.yaml
+      VEND_AWS_SSO_START_URL: https://<your-sso>.awsapps.com/start
+      VEND_AWS_SSO_REGION: us-east-1
     volumes:
       - creds-shelf:/creds          # rw here
       - admin-home:/home/vscode     # SSO cache + ~/.aws


### PR DESCRIPTION
- do not bake custom user names, uid, or gid into the generic image (that is done per-project, if desired)
- automaticaly setup aws configuration and streamline bootstrapping